### PR TITLE
ci: enforce goimports, go mod tidy, and secret-file guards

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -37,7 +37,7 @@ staged_go=$(echo "$staged_all" | grep -E '\.go$' || true)
 if [ -n "$staged_go" ]; then
   if command -v goimports >/dev/null 2>&1; then
     echo "Running goimports on staged Go files..."
-    bad=$(echo "$staged_go" | xargs goimports -l)
+    bad=$(echo "$staged_go" | xargs goimports -l) || true
     if [ -n "$bad" ]; then
       echo "ERROR: the following files are not formatted (run 'goimports -w <file>'):"
       echo "$bad" | sed 's/^/  /'
@@ -60,8 +60,8 @@ if [ "$needs_tidy" -eq 1 ]; then
     echo "'go mod tidy -diff' requires Go 1.23+; skipping (CI will enforce)."
   else
     echo "Checking go.mod / go.sum are tidy..."
-    tidy_out=$(go mod tidy -diff 2>&1)
-    tidy_exit=$?
+    tidy_exit=0
+    tidy_out=$(go mod tidy -diff 2>&1) || tidy_exit=$?
     if [ "$tidy_exit" -eq 0 ]; then
       echo "go.mod / go.sum are tidy."
     elif echo "$tidy_out" | head -1 | grep -qE '^(diff |---|\+\+\+)'; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,10 @@
 #!/bin/sh
-# Pre-commit checks:
+# Pre-commit checks (best-effort, run against working-tree files).
+# CI (.github/workflows/ci.yml) is authoritative and runs the same checks
+# against the committed content. Partial staging within a single file can
+# cause false positives/negatives locally; CI will catch what the hook misses.
+#
+# Checks:
 #   1. Block secret/credential files from being staged
 #   2. Verify staged Go files are formatted with goimports
 #   3. Verify go.mod / go.sum are tidy
@@ -13,9 +18,10 @@ if [ -z "$staged_all" ]; then
   exit 0
 fi
 
-# 1) Block secret/credential files
-forbidden_pattern='(^|/)(\.env(\..+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.pem|.*\.key|.*\.pfx|.*\.p12)$'
-blocked=$(echo "$staged_all" | grep -E "$forbidden_pattern" | grep -vE '(^|/)\.env\.example$' || true)
+# 1) Block secret/credential files (filename heuristics; case-insensitive)
+# Keep this pattern in sync with .github/workflows/ci.yml (forbidden-files job).
+forbidden_pattern='(^|/)(\.env(\..+)?|\.netrc|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.pem|.*\.key|.*\.pfx|.*\.p12|\.aws/credentials|\.aws/config)$'
+blocked=$(echo "$staged_all" | grep -Ei "$forbidden_pattern" | grep -viE '(^|/)\.env\.example$' || true)
 if [ -n "$blocked" ]; then
   echo "ERROR: refusing to commit secret/credential files:"
   echo "$blocked" | sed 's/^/  /'
@@ -49,15 +55,25 @@ needs_tidy=0
 if echo "$staged_all" | grep -qE '(^|/)(go\.mod|go\.sum)$'; then needs_tidy=1; fi
 if [ -n "$staged_go" ]; then needs_tidy=1; fi
 if [ "$needs_tidy" -eq 1 ]; then
-  echo "Checking go.mod / go.sum are tidy..."
-  tidy_out=$(go mod tidy -diff 2>&1 || true)
-  if [ -n "$tidy_out" ]; then
-    echo "ERROR: go.mod / go.sum are not tidy. Run 'go mod tidy' and stage the changes."
-    echo ""
-    echo "$tidy_out"
-    exit 1
+  go_minor=$(go env GOVERSION 2>/dev/null | sed -nE 's/^go1\.([0-9]+).*/\1/p')
+  if [ -z "$go_minor" ] || [ "$go_minor" -lt 23 ]; then
+    echo "'go mod tidy -diff' requires Go 1.23+; skipping (CI will enforce)."
+  else
+    echo "Checking go.mod / go.sum are tidy..."
+    tidy_out=$(go mod tidy -diff 2>&1)
+    tidy_exit=$?
+    if [ "$tidy_exit" -eq 0 ]; then
+      echo "go.mod / go.sum are tidy."
+    elif echo "$tidy_out" | head -1 | grep -qE '^(diff |---|\+\+\+)'; then
+      echo "ERROR: go.mod / go.sum are not tidy. Run 'go mod tidy' and stage the changes."
+      echo ""
+      echo "$tidy_out"
+      exit 1
+    else
+      echo "WARNING: 'go mod tidy -diff' failed (network or toolchain issue); skipping (CI will enforce)."
+      echo "$tidy_out"
+    fi
   fi
-  echo "go.mod / go.sum are tidy."
 fi
 
 # 4) go vet + golangci-lint on staged packages

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,17 +1,71 @@
 #!/bin/sh
-# Run go vet and golangci-lint on staged Go files.
+# Pre-commit checks:
+#   1. Block secret/credential files from being staged
+#   2. Verify staged Go files are formatted with goimports
+#   3. Verify go.mod / go.sum are tidy
+#   4. Run go vet and golangci-lint on staged packages
 
 set -e
 
-# Collect staged .go files (excluding deletions)
-staged_files=$(git diff --cached --name-only --diff-filter=d -- '*.go' || true)
+staged_all=$(git diff --cached --name-only --diff-filter=d || true)
 
-if [ -z "$staged_files" ]; then
+if [ -z "$staged_all" ]; then
   exit 0
 fi
 
-# Extract unique package directories
-packages=$(echo "$staged_files" | xargs -n1 dirname | sort -u | sed 's|^|./|')
+# 1) Block secret/credential files
+forbidden_pattern='(^|/)(\.env(\..+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.pem|.*\.key|.*\.pfx|.*\.p12)$'
+blocked=$(echo "$staged_all" | grep -E "$forbidden_pattern" | grep -vE '(^|/)\.env\.example$' || true)
+if [ -n "$blocked" ]; then
+  echo "ERROR: refusing to commit secret/credential files:"
+  echo "$blocked" | sed 's/^/  /'
+  echo ""
+  echo "  Unstage them: git restore --staged <file>"
+  echo "  If a secret was already committed, also remove it from history and rotate it."
+  exit 1
+fi
+
+staged_go=$(echo "$staged_all" | grep -E '\.go$' || true)
+
+# 2) goimports formatting check (staged Go files only)
+if [ -n "$staged_go" ]; then
+  if command -v goimports >/dev/null 2>&1; then
+    echo "Running goimports on staged Go files..."
+    bad=$(echo "$staged_go" | xargs goimports -l)
+    if [ -n "$bad" ]; then
+      echo "ERROR: the following files are not formatted (run 'goimports -w <file>'):"
+      echo "$bad" | sed 's/^/  /'
+      exit 1
+    fi
+    echo "goimports passed."
+  else
+    echo "goimports not found, skipping (CI will enforce it)."
+    echo "  Install: go install golang.org/x/tools/cmd/goimports@latest"
+  fi
+fi
+
+# 3) go.mod / go.sum tidy freshness
+needs_tidy=0
+if echo "$staged_all" | grep -qE '(^|/)(go\.mod|go\.sum)$'; then needs_tidy=1; fi
+if [ -n "$staged_go" ]; then needs_tidy=1; fi
+if [ "$needs_tidy" -eq 1 ]; then
+  echo "Checking go.mod / go.sum are tidy..."
+  tidy_out=$(go mod tidy -diff 2>&1 || true)
+  if [ -n "$tidy_out" ]; then
+    echo "ERROR: go.mod / go.sum are not tidy. Run 'go mod tidy' and stage the changes."
+    echo ""
+    echo "$tidy_out"
+    exit 1
+  fi
+  echo "go.mod / go.sum are tidy."
+fi
+
+# 4) go vet + golangci-lint on staged packages
+if [ -z "$staged_go" ]; then
+  exit 0
+fi
+
+packages=$(echo "$staged_go" | xargs -n1 dirname | sort -u | sed 's|^|./|')
 
 echo "Running go vet on staged packages..."
 echo "$packages" | xargs go vet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Check goimports formatting
         run: |
           go install golang.org/x/tools/cmd/goimports@v0.45.0
-          bad=$(git ls-files '*.go' | xargs goimports -l)
+          bad=$(git ls-files '*.go' | xargs goimports -l) || true
           if [ -n "$bad" ]; then
             echo "ERROR: files not formatted with goimports:"
             echo "$bad" | sed 's/^/  /'
@@ -115,8 +115,8 @@ jobs:
 
       - name: Check go.mod / go.sum are tidy
         run: |
-          tidy_out=$(go mod tidy -diff 2>&1)
-          tidy_exit=$?
+          tidy_exit=0
+          tidy_out=$(go mod tidy -diff 2>&1) || tidy_exit=$?
           if [ "$tidy_exit" -eq 0 ]; then
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate commit messages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
     name: Block secret/credential files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check tracked files
         # Keep this pattern in sync with .githooks/pre-commit.
@@ -97,9 +97,9 @@ jobs:
     name: Lint and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 
@@ -133,7 +133,7 @@ jobs:
         run: go vet ./...
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Check goimports formatting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check tracked files
+        # Keep this pattern in sync with .githooks/pre-commit.
         run: |
-          forbidden_pattern='(^|/)(\.env(\..+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.pem|.*\.key|.*\.pfx|.*\.p12)$'
-          blocked=$(git ls-files | grep -E "$forbidden_pattern" | grep -vE '(^|/)\.env\.example$' || true)
+          forbidden_pattern='(^|/)(\.env(\..+)?|\.netrc|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.pem|.*\.key|.*\.pfx|.*\.p12|\.aws/credentials|\.aws/config)$'
+          blocked=$(git ls-files | grep -Ei "$forbidden_pattern" | grep -viE '(^|/)\.env\.example$' || true)
           if [ -n "$blocked" ]; then
             echo "ERROR: secret/credential files are tracked in git:"
             echo "$blocked" | sed 's/^/  /'
@@ -104,7 +105,7 @@ jobs:
 
       - name: Check goimports formatting
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
+          go install golang.org/x/tools/cmd/goimports@v0.45.0
           bad=$(git ls-files '*.go' | xargs goimports -l)
           if [ -n "$bad" ]; then
             echo "ERROR: files not formatted with goimports:"
@@ -114,13 +115,19 @@ jobs:
 
       - name: Check go.mod / go.sum are tidy
         run: |
-          tidy_out=$(go mod tidy -diff 2>&1 || true)
-          if [ -n "$tidy_out" ]; then
-            echo "ERROR: go.mod / go.sum are not tidy. Run 'go mod tidy' and commit the changes."
-            echo ""
-            echo "$tidy_out"
-            exit 1
+          tidy_out=$(go mod tidy -diff 2>&1)
+          tidy_exit=$?
+          if [ "$tidy_exit" -eq 0 ]; then
+            exit 0
           fi
+          if echo "$tidy_out" | head -1 | grep -qE '^(diff |---|\+\+\+)'; then
+            echo "ERROR: go.mod / go.sum are not tidy. Run 'go mod tidy' and commit the changes."
+          else
+            echo "ERROR: 'go mod tidy -diff' failed (likely tool or network error, not a tidy issue)."
+          fi
+          echo ""
+          echo "$tidy_out"
+          exit 1
 
       - name: Run go vet
         run: go vet ./...
@@ -128,7 +135,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2.12.2
 
       - name: Run tests
         run: go test -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,22 @@ jobs:
             exit 1
           fi
 
+  forbidden-files:
+    name: Block secret/credential files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tracked files
+        run: |
+          forbidden_pattern='(^|/)(\.env(\..+)?|id_rsa|id_dsa|id_ecdsa|id_ed25519|.*\.pem|.*\.key|.*\.pfx|.*\.p12)$'
+          blocked=$(git ls-files | grep -E "$forbidden_pattern" | grep -vE '(^|/)\.env\.example$' || true)
+          if [ -n "$blocked" ]; then
+            echo "ERROR: secret/credential files are tracked in git:"
+            echo "$blocked" | sed 's/^/  /'
+            exit 1
+          fi
+
   lint-and-test:
     name: Lint and test
     runs-on: ubuntu-latest
@@ -85,6 +101,26 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+
+      - name: Check goimports formatting
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
+          bad=$(git ls-files '*.go' | xargs goimports -l)
+          if [ -n "$bad" ]; then
+            echo "ERROR: files not formatted with goimports:"
+            echo "$bad" | sed 's/^/  /'
+            exit 1
+          fi
+
+      - name: Check go.mod / go.sum are tidy
+        run: |
+          tidy_out=$(go mod tidy -diff 2>&1 || true)
+          if [ -n "$tidy_out" ]; then
+            echo "ERROR: go.mod / go.sum are not tidy. Run 'go mod tidy' and commit the changes."
+            echo ""
+            echo "$tidy_out"
+            exit 1
+          fi
 
       - name: Run go vet
         run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ tmp/
 docker-compose.override.yml
 
 CLAUDE.md
+.claude/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   timeout: 3m
 
@@ -7,18 +9,16 @@ linters:
     - govet
     - staticcheck
     - unused
-    - gosimple
     - ineffassign
     - gocritic
     - revive
-
-linters-settings:
-  revive:
-    rules:
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - style
+  settings:
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - "checkPrivateReceivers"
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,19 @@ verify-fmt:
 
 verify-tidy:
 	@echo "==> go mod tidy"
-	@tidy_out=$$(go mod tidy -diff 2>&1); \
-	if [ -n "$$tidy_out" ]; then echo "ERROR: go.mod / go.sum not tidy (run 'make fmt'):"; echo ""; echo "$$tidy_out"; exit 1; fi
+	@tidy_exit=0; \
+	tidy_out=$$(go mod tidy -diff 2>&1) || tidy_exit=$$?; \
+	if [ "$$tidy_exit" -eq 0 ]; then \
+	  exit 0; \
+	fi; \
+	if echo "$$tidy_out" | head -1 | grep -qE '^(diff |---|\+\+\+)'; then \
+	  echo "ERROR: go.mod / go.sum not tidy (run 'make fmt'):"; \
+	  echo ""; \
+	  echo "$$tidy_out"; \
+	  exit 1; \
+	else \
+	  echo "ERROR: 'go mod tidy -diff' failed (network or toolchain issue):"; \
+	  echo ""; \
+	  echo "$$tidy_out"; \
+	  exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test lint vet docker-up docker-down migrate-up migrate-down setup-hooks check
+.PHONY: build run test lint vet docker-up docker-down migrate-up migrate-down setup-hooks check fmt verify verify-fmt verify-tidy
 
 build:
 	go build -o bin/api ./cmd/api
@@ -32,3 +32,23 @@ setup-hooks:
 	@echo "Git hooks configured to use .githooks/"
 
 check: vet lint test build
+
+fmt:
+	@command -v goimports >/dev/null 2>&1 || { echo "ERROR: goimports not installed."; echo "  go install golang.org/x/tools/cmd/goimports@latest"; exit 1; }
+	goimports -w .
+	go mod tidy
+
+verify: verify-fmt verify-tidy vet lint test build
+	@echo ""
+	@echo "All checks passed."
+
+verify-fmt:
+	@echo "==> goimports"
+	@command -v goimports >/dev/null 2>&1 || { echo "ERROR: goimports not installed (go install golang.org/x/tools/cmd/goimports@latest)"; exit 1; }
+	@bad=$$(git ls-files '*.go' | xargs goimports -l); \
+	if [ -n "$$bad" ]; then echo "ERROR: files not formatted (run 'make fmt'):"; echo "$$bad" | sed 's/^/  /'; exit 1; fi
+
+verify-tidy:
+	@echo "==> go mod tidy"
+	@tidy_out=$$(go mod tidy -diff 2>&1); \
+	if [ -n "$$tidy_out" ]; then echo "ERROR: go.mod / go.sum not tidy (run 'make fmt'):"; echo ""; echo "$$tidy_out"; exit 1; fi

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ See [docs/tickets.md](docs/tickets.md) for detailed ticket design specs.
 - [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) and [golangci-lint](https://golangci-lint.run/), used by the pre-commit hook:
   ```sh
   go install golang.org/x/tools/cmd/goimports@latest
+  brew install golangci-lint   # or see https://golangci-lint.run/welcome/install/
   ```
 
 ### Setup
@@ -76,6 +77,8 @@ See [docs/tickets.md](docs/tickets.md) for detailed ticket design specs.
 | `make vet` | Run go vet |
 | `make setup-hooks` | Configure git to use project hooks |
 | `make check` | Run vet, lint, test, and build in sequence |
+| `make fmt` | Auto-apply `goimports -w` and `go mod tidy` |
+| `make verify` | Run all CI-equivalent gates locally (goimports, tidy, vet, lint, test, build). Read-only; run `make fmt` to fix format/tidy failures. |
 
 ### Hot Reload
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ See [docs/tickets.md](docs/tickets.md) for detailed ticket design specs.
 ### Prerequisites
 - [Docker](https://docs.docker.com/get-docker/) and Docker Compose
 - [Go 1.24+](https://go.dev/dl/) (for local development without Docker)
+- [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) and [golangci-lint](https://golangci-lint.run/), used by the pre-commit hook:
+  ```sh
+  go install golang.org/x/tools/cmd/goimports@latest
+  ```
 
 ### Setup
 
@@ -32,10 +36,16 @@ See [docs/tickets.md](docs/tickets.md) for detailed ticket design specs.
    cp .env.example .env
    ```
 
-2. Set up git hooks:
+2. Set up git hooks (required):
    ```sh
    make setup-hooks
    ```
+   This registers `.githooks/` so every commit is checked for:
+   - Conventional Commits format (`commit-msg`)
+   - Secret/credential files (`.env`, `*.pem`, SSH keys), `goimports` formatting, `go mod tidy` freshness, `go vet`, and `golangci-lint` (`pre-commit`)
+   - Branch name convention `<type>/<description>` (`pre-push`)
+
+   The same checks run in CI, so anything skipped locally will fail the PR.
 
 3. Start the API and database:
    ```sh

--- a/internal/adapters/http/health.go
+++ b/internal/adapters/http/health.go
@@ -9,6 +9,7 @@ type healthResponse struct {
 	Status string `json:"status"`
 }
 
+// HandleHealthz returns an HTTP handler that responds with a JSON liveness status.
 func HandleHealthz() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/adapters/http/middleware/cors.go
+++ b/internal/adapters/http/middleware/cors.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-chi/cors"
 )
 
+// CORS returns middleware that allows requests from origins configured for the
+// given app environment, blocking all cross-origin requests when no origins are allowed.
 func CORS(appEnv string) func(http.Handler) http.Handler {
 	var allowedOrigins []string
 

--- a/internal/adapters/http/middleware/logging.go
+++ b/internal/adapters/http/middleware/logging.go
@@ -11,11 +11,13 @@ type wrappedWriter struct {
 	statusCode int
 }
 
+// WriteHeader records the status code and forwards it to the underlying ResponseWriter.
 func (w *wrappedWriter) WriteHeader(code int) {
 	w.statusCode = code
 	w.ResponseWriter.WriteHeader(code)
 }
 
+// Logging returns middleware that records method, path, status, and duration for each HTTP request.
 func Logging(log *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapters/http/middleware/requestid.go
+++ b/internal/adapters/http/middleware/requestid.go
@@ -11,6 +11,8 @@ type contextKey string
 
 const requestIDKey contextKey = "request_id"
 
+// RequestID is middleware that propagates an incoming X-Request-ID header or
+// generates a new one, attaching it to the request context and response headers.
 func RequestID(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := r.Header.Get("X-Request-ID")
@@ -24,6 +26,7 @@ func RequestID(next http.Handler) http.Handler {
 	})
 }
 
+// GetRequestID returns the request ID stored in the context, or the empty string if none is present.
 func GetRequestID(ctx context.Context) string {
 	if id, ok := ctx.Value(requestIDKey).(string); ok {
 		return id

--- a/internal/adapters/http/middleware/security.go
+++ b/internal/adapters/http/middleware/security.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 )
 
+// SecurityHeaders is middleware that sets common HTTP security response headers
+// (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy).
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -15,6 +17,8 @@ func SecurityHeaders(next http.Handler) http.Handler {
 	})
 }
 
+// Recoverer returns middleware that recovers from panics in downstream handlers,
+// logs the error with request context, and responds with HTTP 500.
 func Recoverer(log *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapters/http/router.go
+++ b/internal/adapters/http/router.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// NewRouter constructs the application's HTTP router with request ID, logging,
+// security headers, CORS, and panic recovery middleware wired in.
 func NewRouter(log *slog.Logger, appEnv string) *chi.Mux {
 	r := chi.NewRouter()
 

--- a/internal/infra/config/config.go
+++ b/internal/infra/config/config.go
@@ -8,17 +8,20 @@ import (
 	"strconv"
 )
 
+// Config holds the full application configuration loaded from the environment.
 type Config struct {
 	App      App
 	Postgres Postgres
 	LogLevel string
 }
 
+// App holds general application settings (environment and port).
 type App struct {
 	Env  string
 	Port int
 }
 
+// Postgres holds PostgreSQL connection parameters.
 type Postgres struct {
 	Host     string
 	Port     int
@@ -27,6 +30,7 @@ type Postgres struct {
 	DB       string
 }
 
+// DSN returns the PostgreSQL connection string with sslmode disabled.
 func (p Postgres) DSN() string {
 	u := url.URL{
 		Scheme:   "postgres",
@@ -38,6 +42,8 @@ func (p Postgres) DSN() string {
 	return u.String()
 }
 
+// Load reads the application configuration from environment variables,
+// returning an error if any required variable is missing or invalid.
 func Load() (Config, error) {
 	var errs []error
 

--- a/internal/infra/logger/logger.go
+++ b/internal/infra/logger/logger.go
@@ -5,7 +5,8 @@ import (
 	"log/slog"
 )
 
-// dev uses human-readable; all other environments use JSON.
+// New returns a slog.Logger configured for the given environment: human-readable
+// text in development, JSON elsewhere, both filtered by the given level.
 func New(w io.Writer, env string, level slog.Level) *slog.Logger {
 	opts := &slog.HandlerOptions{Level: level}
 
@@ -19,6 +20,8 @@ func New(w io.Writer, env string, level slog.Level) *slog.Logger {
 	return slog.New(handler)
 }
 
+// ParseLevel converts a level name (debug, info, warn, error) to a slog.Level,
+// defaulting to LevelInfo for unrecognized values.
 func ParseLevel(s string) slog.Level {
 	switch s {
 	case "debug":


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly tooling, workflow, and documentation; CI now uses Go 1.25 while go.mod still declares 1.24.4, which may surprise local/CI parity until aligned.
> 
> **Overview**
> Aligns **local git hooks**, **CI**, and **Make** so the same quality gates run before merge: block credential-like paths, enforce **goimports** and **`go mod tidy`**, then **go vet** / **golangci-lint**.
> 
> The **pre-commit** hook grows from vet/lint-only to a four-step pipeline (secret filename heuristics shared with CI, staged **goimports**, tidy check when Go ≥ 1.23, then existing package vet/lint), with explicit notes that CI is authoritative and partial staging can skew local results.
> 
> **CI** adds a **forbidden-files** job, **goimports** and **tidy** steps in **lint-and-test**, bumps **checkout/setup-go** (Go **1.25**), and pins **golangci-lint** v7 / v2.12.2. **`.golangci.yml`** moves to config **version 2** (drops **gosimple**; **revive**/**gocritic** settings under **`linters.settings`**). **Makefile** adds **`fmt`** / **`verify`** targets mirroring CI; **README** documents hook tooling and **`make verify`**. **`.gitignore`** ignores **`.claude/`**. Exported Go symbols get **godoc** comments to satisfy stricter lint/export rules—no runtime behavior change there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa4e41cf2df7e57c26209b3c959a8d1ff447ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->